### PR TITLE
Correct S/MIME acronym definition

### DIFF
--- a/certificate-policy.md
+++ b/certificate-policy.md
@@ -349,7 +349,7 @@ The binding SHALL use a digital signature algorithm or a cryptographic hash algo
 | OID | Object Identifier |
 | PKI | Public Key Infrastructure |
 | RA | Registration Authority |
-| S/MIME | Secure MIME (purpose Internet Mail Extensions) |
+| S/MIME | Secure MIME (Multipurpose Internet Mail Extensions) |
 | SSL | Secure Sockets Layer |
 | TLD | Top-Level Domain |
 | TLS | Transport Layer Security |


### PR DESCRIPTION
The definition of MIME in S/MIME in Section 1.6.2 should be "Multipurpose Internet Mail Extensions" rather than "purpose Internet Mail Extensions"