### PR TITLE
Correct definition of "Effective Date"

### DIFF
--- a/certificate-policy.md
+++ b/certificate-policy.md
@@ -196,7 +196,7 @@ Prior to submitting a CPS, the CA shall commission a compliance analysis study c
 
 **Domain Name Registrar**: A person or entity that registers Domain Names under the auspices of or by agreement with: (i) the Internet Corporation for Assigned Names and Numbers (ICANN), (ii) a national Domain Name authority/registry, or (iii) a Network Information Center (including their affiliates, contractors, delegates, successors, or assigns).
 
-**Effective Date**: 1 July 2012.
+**Effective Date**: The date, as specified in Section 1.2.1, by which entites need to conform to the specified revision of this policy.
 
 **Embedded SCT**: An SCT delivered via an X.509v3 extension within the certificate.
 

--- a/certificate-policy.md
+++ b/certificate-policy.md
@@ -196,7 +196,7 @@ Prior to submitting a CPS, the CA shall commission a compliance analysis study c
 
 **Domain Name Registrar**: A person or entity that registers Domain Names under the auspices of or by agreement with: (i) the Internet Corporation for Assigned Names and Numbers (ICANN), (ii) a national Domain Name authority/registry, or (iii) a Network Information Center (including their affiliates, contractors, delegates, successors, or assigns).
 
-**Effective Date**: The date, as specified in Section 1.2.1, by which entites need to conform to the specified revision of this policy.
+**Effective Date**: The date, as specified in Section 1.2.1, by which entities need to conform to the specified revision of this policy.
 
 **Embedded SCT**: An SCT delivered via an X.509v3 extension within the certificate.
 


### PR DESCRIPTION
"Effective Date" is currently defined in Section 1.6.1. as "1 July 2012," which was the effective date of version 1.0.0 of the CA/Browser Forum's Baseline Requirements CP. My proposed definition may not be the best, but the current one needs to be replaced.