### PR TITLE
Remove double shall in Section 6.1.6

### DIFF
--- a/certificate-policy.md
+++ b/certificate-policy.md
@@ -1465,7 +1465,7 @@ Certificates MUST meet the following requirements for algorithm type and key siz
 \*\*\* L and N (the bit lengths of modulus p and divisor q, respectively) are described in the Digital Signature Standard, FIPS 186-4 (http://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.186-4.pdf).
 
 ### 6.1.6 Public key parameters generation and quality checking
-RSA: The CA SHALL confirm that the value of the public exponent _e_ shall be an odd positive integer such that:  
+RSA: The CA SHALL confirm that the value of the public exponent _e_ is an odd positive integer such that:  
 
 - 2<sup>16</sup> < e < 2<sup>256</sup>  
 


### PR DESCRIPTION
Section 6.1.6 says that "The CA SHALL confirm that the value of the public exponent e shall be an odd positive integer," which suggests that the CA has to confirm that the requirement exists rather than confirming that the exponent meets the requirement. The CA needs to confirm that e "is" an odd positive integer, not that it "shall be" one.