### PR TITLE
Created representative root, subordinate, and end-entity certificates via OpenSSL

### DIFF
--- a/sampleOpenSSLCertificates/0-root.md
+++ b/sampleOpenSSLCertificates/0-root.md
@@ -1,0 +1,129 @@
+```
+-----BEGIN CERTIFICATE-----
+MIIFxzCCA6+gAwIBAgIJAJSHyltKQoeoMA0GCSqGSIb3DQEBCwUAMFExCzAJBgNV
+BAYTAlVTMRgwFgYDVQQKEw9VLlMuIEdvdmVybm1lbnQxKDAmBgNVBAMTH1VTIEZl
+ZGVyYWwgVGVzdCBUTFMgUm9vdCBDQSAxMDAwHhcNMTgwNDA0MjAyMjEyWhcNMzgw
+MzMwMjAyMjEyWjBRMQswCQYDVQQGEwJVUzEYMBYGA1UEChMPVS5TLiBHb3Zlcm5t
+ZW50MSgwJgYDVQQDEx9VUyBGZWRlcmFsIFRlc3QgVExTIFJvb3QgQ0EgMTAwMIIC
+IjANBgkqhkiG9w0BAQEFAAOCAg8AMIICCgKCAgEAzAHEnzmrFp3quIf4zvFokTGJ
+/DJx4+SzoJLnQkJpEZjtZMxHRn0T5ZlR9G5CvrpsNOCUcuo1T3XFl8c0AlX6Dfey
+aaNViwK/0se9UThJTmlxqLQdvTn23k7RfAFQfjiuV7cYrh9KFWgk+q2qSnMXbqum
+/KvUMh6jUaCKObOfrIgJmSP39uj+h7LXzGTMYq6gpxCXUtEbeTnKFRv71BxuAWF0
+Jk4dWJ5eQot6oFh3zvLxe2U1W32VwZqPclD8ov6s+u6rvxotH/WQRjPxZ82gkpTn
+CuwRwgCRDYOYGZd1iWTKFy02WVkgf2/DD4ycZno2iNsioHvK+s0lNFrjXBsD37En
+SdxeJ9Epi0x4YZeY80oVGKpb/kWzcwIGp/ng6MAkpolCNqqKThg+wPGSNrasgnts
+2IeMSVEzPJlj+e08JlmbI/LYFJHkQHT46/zJl+v8oyfaIVRJ9Mu6HgUfy4zJljSs
+ZX5vZG/BnWmCVD6gIlpOjLwM2TXj5keccNHoyx/eMgJHyZbY65EFlsu5zWqAjjrs
+yZYmCxxgdg2geFnjyO4WAc+74leWpZ91JGGBh5ErBhGaa7ID6LoYDAqEsa0y+0a7
+XBBwv7Oxb0NppzmpdyqBUrjIjzPwFqrlzsSvxibn1E+1Zi94Rl573XuhpXsR3lOF
+Zysj8s8SGxfP8V3f80MCAwEAAaOBoTCBnjAdBgNVHQ4EFgQUjNP5rc+ocFIwVwGG
+r8BraLWoNcUwDwYDVR0TAQH/BAUwAwEB/zAOBgNVHQ8BAf8EBAMCAYYwXAYIKwYB
+BQUHAQsEUDBOMEwGCCsGAQUFBzAFhkBodHRwOi8vdGxzcm9vdC5wa2ktbGFiLmdv
+di9jYUNlcnRzSXNzdWVkQnlVU0ZFRFRFU1RST09UQ0ExMDAucDdjMA0GCSqGSIb3
+DQEBCwUAA4ICAQAI0LjuviowiQB7r43GBSePNcYzL2K7mbY9aDDrV6a6/lu3RRs9
+dUkMxyZ9kX1iBlnVv4jvPhmoR7TyCW6vpdgCVhmwF2j85sZW/8R5SdeZPWBw/vFR
+M7L9+TBeTpl40caGi2VCFVmW06FFW8xWND/x+hqkERyAlpnFmMfIb/4AQzhlCh7Q
+2DRjV82M1omSpJxMW8Jp5ac/qnJLM7kqL/UADAHFJJSebfOGbkZdi2ncuyt4bb0c
+Qzt/UB1XKbgCPM84nxl3WMfEGcFDvEBA39uNhVySiyvVZUjC1jn0QnWvSt0NZPLQ
+4jdXOwaXEzlw682vY1CN4NXrt6bpz6rX4WRkwX+0VaFDMGw3pjh6nT6WRXM3frtG
+AcS9fuEP5KanUZNw4wKBk5wuZ/3fDFCHhNTiirtmZSYemUwmySODQ9tE9ywy7XPa
+gayJHEOdnzunJZvHl1LJbdlnf2GUF5A7vQqDUlIZFkx6XcSqf3QzA5Rxu5a5Y63x
+ILxzNsf98lbb/XcLqW9tUBniYvAy2Ubx77NwngNaV/kfvOhujPPPotv1AlN9BYBz
+fbXpCeBXcNk8F7/KA2f6dP9Ef2bdIkiE9HtxJDR/UxnDeW1qgDTLA4imjg+BjW7q
+JoIpmODXEv6fo0md5IyLItW7Q2K4w8YxPlfXaB6xXSZlDmnysA7qqEyZcA==
+-----END CERTIFICATE-----
+```
+
+
+```
+    Data:
+        Version: 3 (0x2)
+        Serial Number:
+            94:87:ca:5b:4a:42:87:a8
+    Signature Algorithm: sha256WithRSAEncryption
+        Issuer: C=US, O=U.S. Government, CN=US Federal Test TLS Root CA 100
+        Validity
+            Not Before: Apr  4 20:22:12 2018 GMT
+            Not After : Mar 30 20:22:12 2038 GMT
+        Subject: C=US, O=U.S. Government, CN=US Federal Test TLS Root CA 100
+        Subject Public Key Info:
+            Public Key Algorithm: rsaEncryption
+                Public-Key: (4096 bit)
+                Modulus:
+                    00:cc:01:c4:9f:39:ab:16:9d:ea:b8:87:f8:ce:f1:
+                    68:91:31:89:fc:32:71:e3:e4:b3:a0:92:e7:42:42:
+                    69:11:98:ed:64:cc:47:46:7d:13:e5:99:51:f4:6e:
+                    42:be:ba:6c:34:e0:94:72:ea:35:4f:75:c5:97:c7:
+                    34:02:55:fa:0d:f7:b2:69:a3:55:8b:02:bf:d2:c7:
+                    bd:51:38:49:4e:69:71:a8:b4:1d:bd:39:f6:de:4e:
+                    d1:7c:01:50:7e:38:ae:57:b7:18:ae:1f:4a:15:68:
+                    24:fa:ad:aa:4a:73:17:6e:ab:a6:fc:ab:d4:32:1e:
+                    a3:51:a0:8a:39:b3:9f:ac:88:09:99:23:f7:f6:e8:
+                    fe:87:b2:d7:cc:64:cc:62:ae:a0:a7:10:97:52:d1:
+                    1b:79:39:ca:15:1b:fb:d4:1c:6e:01:61:74:26:4e:
+                    1d:58:9e:5e:42:8b:7a:a0:58:77:ce:f2:f1:7b:65:
+                    35:5b:7d:95:c1:9a:8f:72:50:fc:a2:fe:ac:fa:ee:
+                    ab:bf:1a:2d:1f:f5:90:46:33:f1:67:cd:a0:92:94:
+                    e7:0a:ec:11:c2:00:91:0d:83:98:19:97:75:89:64:
+                    ca:17:2d:36:59:59:20:7f:6f:c3:0f:8c:9c:66:7a:
+                    36:88:db:22:a0:7b:ca:fa:cd:25:34:5a:e3:5c:1b:
+                    03:df:b1:27:49:dc:5e:27:d1:29:8b:4c:78:61:97:
+                    98:f3:4a:15:18:aa:5b:fe:45:b3:73:02:06:a7:f9:
+                    e0:e8:c0:24:a6:89:42:36:aa:8a:4e:18:3e:c0:f1:
+                    92:36:b6:ac:82:7b:6c:d8:87:8c:49:51:33:3c:99:
+                    63:f9:ed:3c:26:59:9b:23:f2:d8:14:91:e4:40:74:
+                    f8:eb:fc:c9:97:eb:fc:a3:27:da:21:54:49:f4:cb:
+                    ba:1e:05:1f:cb:8c:c9:96:34:ac:65:7e:6f:64:6f:
+                    c1:9d:69:82:54:3e:a0:22:5a:4e:8c:bc:0c:d9:35:
+                    e3:e6:47:9c:70:d1:e8:cb:1f:de:32:02:47:c9:96:
+                    d8:eb:91:05:96:cb:b9:cd:6a:80:8e:3a:ec:c9:96:
+                    26:0b:1c:60:76:0d:a0:78:59:e3:c8:ee:16:01:cf:
+                    bb:e2:57:96:a5:9f:75:24:61:81:87:91:2b:06:11:
+                    9a:6b:b2:03:e8:ba:18:0c:0a:84:b1:ad:32:fb:46:
+                    bb:5c:10:70:bf:b3:b1:6f:43:69:a7:39:a9:77:2a:
+                    81:52:b8:c8:8f:33:f0:16:aa:e5:ce:c4:af:c6:26:
+                    e7:d4:4f:b5:66:2f:78:46:5e:7b:dd:7b:a1:a5:7b:
+                    11:de:53:85:67:2b:23:f2:cf:12:1b:17:cf:f1:5d:
+                    df:f3:43
+                Exponent: 65537 (0x10001)
+        X509v3 extensions:
+            X509v3 Subject Key Identifier:
+                8C:D3:F9:AD:CF:A8:70:52:30:57:01:86:AF:C0:6B:68:B5:A8:35:C5
+            X509v3 Basic Constraints: critical
+                CA:TRUE
+            X509v3 Key Usage: critical
+                Digital Signature, Certificate Sign, CRL Sign
+            Subject Information Access:
+                CA Repository - URI:http://tlsroot.pki-lab.gov/caCertsIssuedByUSFEDTESTROOTCA100.p7c
+
+    Signature Algorithm: sha256WithRSAEncryption
+         08:d0:b8:ee:be:2a:30:89:00:7b:af:8d:c6:05:27:8f:35:c6:
+         33:2f:62:bb:99:b6:3d:68:30:eb:57:a6:ba:fe:5b:b7:45:1b:
+         3d:75:49:0c:c7:26:7d:91:7d:62:06:59:d5:bf:88:ef:3e:19:
+         a8:47:b4:f2:09:6e:af:a5:d8:02:56:19:b0:17:68:fc:e6:c6:
+         56:ff:c4:79:49:d7:99:3d:60:70:fe:f1:51:33:b2:fd:f9:30:
+         5e:4e:99:78:d1:c6:86:8b:65:42:15:59:96:d3:a1:45:5b:cc:
+         56:34:3f:f1:fa:1a:a4:11:1c:80:96:99:c5:98:c7:c8:6f:fe:
+         00:43:38:65:0a:1e:d0:d8:34:63:57:cd:8c:d6:89:92:a4:9c:
+         4c:5b:c2:69:e5:a7:3f:aa:72:4b:33:b9:2a:2f:f5:00:0c:01:
+         c5:24:94:9e:6d:f3:86:6e:46:5d:8b:69:dc:bb:2b:78:6d:bd:
+         1c:43:3b:7f:50:1d:57:29:b8:02:3c:cf:38:9f:19:77:58:c7:
+         c4:19:c1:43:bc:40:40:df:db:8d:85:5c:92:8b:2b:d5:65:48:
+         c2:d6:39:f4:42:75:af:4a:dd:0d:64:f2:d0:e2:37:57:3b:06:
+         97:13:39:70:eb:cd:af:63:50:8d:e0:d5:eb:b7:a6:e9:cf:aa:
+         d7:e1:64:64:c1:7f:b4:55:a1:43:30:6c:37:a6:38:7a:9d:3e:
+         96:45:73:37:7e:bb:46:01:c4:bd:7e:e1:0f:e4:a6:a7:51:93:
+         70:e3:02:81:93:9c:2e:67:fd:df:0c:50:87:84:d4:e2:8a:bb:
+         66:65:26:1e:99:4c:26:c9:23:83:43:db:44:f7:2c:32:ed:73:
+         da:81:ac:89:1c:43:9d:9f:3b:a7:25:9b:c7:97:52:c9:6d:d9:
+         67:7f:61:94:17:90:3b:bd:0a:83:52:52:19:16:4c:7a:5d:c4:
+         aa:7f:74:33:03:94:71:bb:96:b9:63:ad:f1:20:bc:73:36:c7:
+         fd:f2:56:db:fd:77:0b:a9:6f:6d:50:19:e2:62:f0:32:d9:46:
+         f1:ef:b3:70:9e:03:5a:57:f9:1f:bc:e8:6e:8c:f3:cf:a2:db:
+         f5:02:53:7d:05:80:73:7d:b5:e9:09:e0:57:70:d9:3c:17:bf:
+         ca:03:67:fa:74:ff:44:7f:66:dd:22:48:84:f4:7b:71:24:34:
+         7f:53:19:c3:79:6d:6a:80:34:cb:03:88:a6:8e:0f:81:8d:6e:
+         ea:26:82:29:98:e0:d7:12:fe:9f:a3:49:9d:e4:8c:8b:22:d5:
+         bb:43:62:b8:c3:c6:31:3e:57:d7:68:1e:b1:5d:26:65:0e:69:
+         f2:b0:0e:ea:a8:4c:99:70
+```   

--- a/sampleOpenSSLCertificates/1-subordinate.md
+++ b/sampleOpenSSLCertificates/1-subordinate.md
@@ -1,0 +1,139 @@
+```
+-----BEGIN CERTIFICATE-----
+MIIGITCCBAmgAwIBAgIUY8oixrVBcjB1zstuAMx8xOBPLkUwDQYJKoZIhvcNAQEL
+BQAwUTELMAkGA1UEBhMCVVMxGDAWBgNVBAoTD1UuUy4gR292ZXJubWVudDEoMCYG
+A1UEAxMfVVMgRmVkZXJhbCBUZXN0IFRMUyBSb290IENBIDEwMDAeFw0xODA0MDQy
+MDI0NDFaFw0yODA0MDEyMDI0NDFaMEwxCzAJBgNVBAYTAlVTMRgwFgYDVQQKEw9V
+LlMuIEdvdmVybm1lbnQxIzAhBgNVBAMTGlVTIEZlZGVyYWwgVGVzdCBUTFMgQ0Eg
+MTAwMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAtjG+0nbVLmII6pKY
+IyUXJuworAFHQVzwG/fGNP+q7DiHvNqxB8KbCDAOJgbwvHWbEyu70+LfjKrAv45F
+g+ZHTvyz4Yu+IELD+tjj95IMNElonSlAyJXtcekY6mGN+1M9NiShoiTfXSIcyq5O
+uvjfP8N1PUX3QHf1s1Galk2MXuVqMzpZeQgfsaM1J6e/0BNy2uk8JjgxEADClgSn
+E6N3ohdjsoS+AdKI7ICkukzPfYhNJ2rJiY5f4bRSpUqE4WD69DV4qTg4/4lgJ3Gf
+zwjE2uTajDr4Zi6bElTr159hdZY65KiIQ+P6jhxdyLpJI7afNtNyrSezlLC9YShl
+0yEbuQIDAQABo4IB9DCCAfAwHQYDVR0OBBYEFH5OK/Fksq2rf2KRMDDVVMbSO1Xh
+MB8GA1UdIwQYMBaAFIzT+a3PqHBSMFcBhq/Aa2i1qDXFMBIGA1UdEwEB/wQIMAYB
+Af8CAQAwDgYDVR0PAQH/BAQDAgEGMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEF
+BQcDAjA5BgNVHSAEMjAwMAwGCmCGSAFlAwIBAyswDAYKYIZIAWUDAgEDLDAIBgZn
+gQwBAgEwCAYGZ4EMAQICMIGEBggrBgEFBQcBAQR4MHYwKwYIKwYBBQUHMAGGH2h0
+dHA6Ly9vY3NwLnRsc3Jvb3QucGtpLWxhYi5nb3YwRwYIKwYBBQUHMAKGO2h0dHA6
+Ly9jZXJ0LnRsc3Jvb3QucGtpLWxhYi5nb3Yvc2lnbi9VU0ZFRFRFU1RST09UQ0Ex
+MDAucDdjMEYGA1UdHwQ/MD0wO6A5oDeGNWh0dHA6Ly90bHNyb290LnBraS1sYWIu
+Z292L2NybC9VU0ZFRFRFU1RST09UQ0ExMDAuY3JsMGEGA1UdHgEB/wRXMFWgITAR
+pA8wDTELMAkGA1UEBhMCVVMwBYIDbWlsMAWCA2dvdqEwMAqHCAAAAAAAAAAAMCKH
+IAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMA0GCSqGSIb3DQEBCwUA
+A4ICAQCxFgyZmvqSBSHu0pSALLcQ+pXk4NTyIDA2DJQlISLPJkmWHHHE3RdRFIWF
+V67Di9okV0G1CrR1dNboI75AbM+IPmXRiXS7AVgFLKLqPFzOz3g26LNGSGQ2CKmK
+T0XbOXAP84zZWm3loPlLr2UxkrpK6r1JRgNpmC2iVn6QjGFZ7xS8I1el/H6sK7IO
+RgcPdbJEwaDUgoGj3v7HB6Vwlt58MziXbn/TLASGTqwEtcOkL03BkCgd0oja7jqd
+amjaZRI76n7dbkPh7Zq2pUXcsu8rca8Yr+2SgeDlguH0FS9wrQBdxTt8AgjarYlR
+h4XIhUShZ+mrXiehQ4nD4igN7z7TTs0A0czUZXvs5ar44bN96agik1bPvnqc5VFF
+sFmONBKPZYb+J7IgZ0acua5fSnbaYPi7hd9fBNGTsMftJd/pt8JpBSz78I7H1b2l
+nkhndz6QCyVDIs2cw+ovkFMZdjzGXfpAk8PxJDiX1Pt/4O4hDHRDL/kGvV72oqM5
+l9kafpcvr/q3ElwdzJxoB9Xt+7kbecSYwI+hrXUr8GmnTOtMqVHIsZyH0hthCui2
+v1ybcOwvEbeFgIQml8RfZ5gSf+LZCH30cy2pkAXmyaWRllHz9Cccns4PE9NuXGdC
+CbKcPB/2WniGgL1HexXP6GOb2W3A8K/mppdVg/aVmiYAio+jZA==
+-----END CERTIFICATE-----
+```
+
+```
+    Data:
+        Version: 3 (0x2)
+        Serial Number:
+            63:ca:22:c6:b5:41:72:30:75:ce:cb:6e:00:cc:7c:c4:e0:4f:2e:45
+    Signature Algorithm: sha256WithRSAEncryption
+        Issuer: C=US, O=U.S. Government, CN=US Federal Test TLS Root CA 100
+        Validity
+            Not Before: Apr  4 20:24:41 2018 GMT
+            Not After : Apr  1 20:24:41 2028 GMT
+        Subject: C=US, O=U.S. Government, CN=US Federal Test TLS CA 100
+        Subject Public Key Info:
+            Public Key Algorithm: rsaEncryption
+                Public-Key: (2048 bit)
+                Modulus:
+                    00:b6:31:be:d2:76:d5:2e:62:08:ea:92:98:23:25:
+                    17:26:ec:28:ac:01:47:41:5c:f0:1b:f7:c6:34:ff:
+                    aa:ec:38:87:bc:da:b1:07:c2:9b:08:30:0e:26:06:
+                    f0:bc:75:9b:13:2b:bb:d3:e2:df:8c:aa:c0:bf:8e:
+                    45:83:e6:47:4e:fc:b3:e1:8b:be:20:42:c3:fa:d8:
+                    e3:f7:92:0c:34:49:68:9d:29:40:c8:95:ed:71:e9:
+                    18:ea:61:8d:fb:53:3d:36:24:a1:a2:24:df:5d:22:
+                    1c:ca:ae:4e:ba:f8:df:3f:c3:75:3d:45:f7:40:77:
+                    f5:b3:51:9a:96:4d:8c:5e:e5:6a:33:3a:59:79:08:
+                    1f:b1:a3:35:27:a7:bf:d0:13:72:da:e9:3c:26:38:
+                    31:10:00:c2:96:04:a7:13:a3:77:a2:17:63:b2:84:
+                    be:01:d2:88:ec:80:a4:ba:4c:cf:7d:88:4d:27:6a:
+                    c9:89:8e:5f:e1:b4:52:a5:4a:84:e1:60:fa:f4:35:
+                    78:a9:38:38:ff:89:60:27:71:9f:cf:08:c4:da:e4:
+                    da:8c:3a:f8:66:2e:9b:12:54:eb:d7:9f:61:75:96:
+                    3a:e4:a8:88:43:e3:fa:8e:1c:5d:c8:ba:49:23:b6:
+                    9f:36:d3:72:ad:27:b3:94:b0:bd:61:28:65:d3:21:
+                    1b:b9
+                Exponent: 65537 (0x10001)
+        X509v3 extensions:
+            X509v3 Subject Key Identifier:
+                7E:4E:2B:F1:64:B2:AD:AB:7F:62:91:30:30:D5:54:C6:D2:3B:55:E1
+            X509v3 Authority Key Identifier:
+                keyid:8C:D3:F9:AD:CF:A8:70:52:30:57:01:86:AF:C0:6B:68:B5:A8:35:C5
+
+            X509v3 Basic Constraints: critical
+                CA:TRUE, pathlen:0
+            X509v3 Key Usage: critical
+                Certificate Sign, CRL Sign
+            X509v3 Extended Key Usage:
+                TLS Web Server Authentication, TLS Web Client Authentication
+            X509v3 Certificate Policies:
+                Policy: 2.16.840.1.101.3.2.1.3.43
+                Policy: 2.16.840.1.101.3.2.1.3.44
+                Policy: 2.23.140.1.2.1
+                Policy: 2.23.140.1.2.2
+
+            Authority Information Access:
+                OCSP - URI:http://ocsp.tlsroot.pki-lab.gov
+                CA Issuers - URI:http://cert.tlsroot.pki-lab.gov/sign/USFEDTESTROOTCA100.p7c
+
+            X509v3 CRL Distribution Points:
+
+                Full Name:
+                  URI:http://tlsroot.pki-lab.gov/crl/USFEDTESTROOTCA100.crl
+
+            X509v3 Name Constraints: critical
+                Permitted:
+                  DirName: C = US
+                  DNS:mil
+                  DNS:gov
+                Excluded:
+                  IP:0.0.0.0/0.0.0.0
+                  IP:0:0:0:0:0:0:0:0/0:0:0:0:0:0:0:0
+
+    Signature Algorithm: sha256WithRSAEncryption
+         b1:16:0c:99:9a:fa:92:05:21:ee:d2:94:80:2c:b7:10:fa:95:
+         e4:e0:d4:f2:20:30:36:0c:94:25:21:22:cf:26:49:96:1c:71:
+         c4:dd:17:51:14:85:85:57:ae:c3:8b:da:24:57:41:b5:0a:b4:
+         75:74:d6:e8:23:be:40:6c:cf:88:3e:65:d1:89:74:bb:01:58:
+         05:2c:a2:ea:3c:5c:ce:cf:78:36:e8:b3:46:48:64:36:08:a9:
+         8a:4f:45:db:39:70:0f:f3:8c:d9:5a:6d:e5:a0:f9:4b:af:65:
+         31:92:ba:4a:ea:bd:49:46:03:69:98:2d:a2:56:7e:90:8c:61:
+         59:ef:14:bc:23:57:a5:fc:7e:ac:2b:b2:0e:46:07:0f:75:b2:
+         44:c1:a0:d4:82:81:a3:de:fe:c7:07:a5:70:96:de:7c:33:38:
+         97:6e:7f:d3:2c:04:86:4e:ac:04:b5:c3:a4:2f:4d:c1:90:28:
+         1d:d2:88:da:ee:3a:9d:6a:68:da:65:12:3b:ea:7e:dd:6e:43:
+         e1:ed:9a:b6:a5:45:dc:b2:ef:2b:71:af:18:af:ed:92:81:e0:
+         e5:82:e1:f4:15:2f:70:ad:00:5d:c5:3b:7c:02:08:da:ad:89:
+         51:87:85:c8:85:44:a1:67:e9:ab:5e:27:a1:43:89:c3:e2:28:
+         0d:ef:3e:d3:4e:cd:00:d1:cc:d4:65:7b:ec:e5:aa:f8:e1:b3:
+         7d:e9:a8:22:93:56:cf:be:7a:9c:e5:51:45:b0:59:8e:34:12:
+         8f:65:86:fe:27:b2:20:67:46:9c:b9:ae:5f:4a:76:da:60:f8:
+         bb:85:df:5f:04:d1:93:b0:c7:ed:25:df:e9:b7:c2:69:05:2c:
+         fb:f0:8e:c7:d5:bd:a5:9e:48:67:77:3e:90:0b:25:43:22:cd:
+         9c:c3:ea:2f:90:53:19:76:3c:c6:5d:fa:40:93:c3:f1:24:38:
+         97:d4:fb:7f:e0:ee:21:0c:74:43:2f:f9:06:bd:5e:f6:a2:a3:
+         39:97:d9:1a:7e:97:2f:af:fa:b7:12:5c:1d:cc:9c:68:07:d5:
+         ed:fb:b9:1b:79:c4:98:c0:8f:a1:ad:75:2b:f0:69:a7:4c:eb:
+         4c:a9:51:c8:b1:9c:87:d2:1b:61:0a:e8:b6:bf:5c:9b:70:ec:
+         2f:11:b7:85:80:84:26:97:c4:5f:67:98:12:7f:e2:d9:08:7d:
+         f4:73:2d:a9:90:05:e6:c9:a5:91:96:51:f3:f4:27:1c:9e:ce:
+         0f:13:d3:6e:5c:67:42:09:b2:9c:3c:1f:f6:5a:78:86:80:bd:
+         47:7b:15:cf:e8:63:9b:d9:6d:c0:f0:af:e6:a6:97:55:83:f6:
+         95:9a:26:00:8a:8f:a3:64
+```         

--- a/sampleOpenSSLCertificates/2-ocsp.md
+++ b/sampleOpenSSLCertificates/2-ocsp.md
@@ -1,0 +1,101 @@
+```
+-----BEGIN CERTIFICATE-----
+MIIENzCCAx+gAwIBAgIUTz67V9YfdBCwHHjMHJxGftgMpb0wDQYJKoZIhvcNAQEL
+BQAwTDELMAkGA1UEBhMCVVMxGDAWBgNVBAoTD1UuUy4gR292ZXJubWVudDEjMCEG
+A1UEAxMaVVMgRmVkZXJhbCBUZXN0IFRMUyBDQSAxMDAwHhcNMTgwNDA0MjAzMDA4
+WhcNMTgwNTE5MjAzMDA4WjBOMQswCQYDVQQGEwJVUzEYMBYGA1UEChMPVS5TLiBH
+b3Zlcm5tZW50MSUwIwYDVQQDExxPQ1NQIFNpZ25pbmcgQ2VydGlmaWNhdGUgMTAw
+MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAw69WApVVHYFKRSU81y90
+Pdkav4Xi+fCbToXhm3a6EMuqohUHVbifiyQAQi8tLjwDvwQsj9ZZQgNaqGsI9Ppc
+8bYKrLT3O3VnKTqyv+T211jPlj80bi+Hohv/M8+mhgxGuwrdpanGujbxuHzo2N7+
+4bUWOnfocW7JxA7aqQRH03wtJuPicwxo/o4q75ElMvSy/x5XlBYllfP0OFKyhhbS
+agBM3kYS9Axd/OeTK6e+rxMkLW3mSNPUCp18gTvbUpLBOUE1ujnVhy4dnqB/9fkX
+JivP9vfO9XkLCCgban8fVrq9qu9qiNzBSvVvriuMYnGIKJav0VB7ir1YnHVsgA7M
+LQIDAQABo4IBDTCCAQkwHwYDVR0jBBgwFoAUfk4r8WSyrat/YpEwMNVUxtI7VeEw
+HQYDVR0OBBYEFAl+uXlpjbc/Eb/sjhG+DzAzUQUQMDkGA1UdIAQyMDAwDAYKYIZI
+AWUDAgEDKzAMBgpghkgBZQMCAQMsMAgGBmeBDAECATAIBgZngQwBAgIwDgYDVR0P
+AQH/BAQDAgeAMBYGA1UdJQEB/wQMMAoGCCsGAQUFBwMJMA8GCSsGAQUFBzABBQQC
+BQAwUwYIKwYBBQUHAQEERzBFMEMGCCsGAQUFBzAChjdodHRwOi8vY2VydC5pc3N1
+aW5nLnBraS1sYWIuZ292L3NpZ24vVVNGRURURVNUQ0ExMDAucDdjMA0GCSqGSIb3
+DQEBCwUAA4IBAQBW0A4sKz9hqiV8fFvZRbd3yShf169dCWXDlg1B8EdD2JdJLGIE
+3rh5spEgFhWzz903n42JhXSWVkCcSmGBTboCEOmrRrG3J401SJ+7vNNwExXEwS26
+WZrQRO+T0iKtZoBjZfUFVEyERpWdExy3p++mNEEexGZcw5dGep23iQkNzN8DZVs4
+QBAa2g6HTp0RS+vcv40RTRO/0yi0Q24h831Zz8WNtMPmLr2SSJprPFYv2fX2N/5Z
+uNeWqh84HPWB2NAezsAHLzHQWCyo0dGlgp4jPXGD7a+2O6UcrfiJFpqrGjfnvKWj
+GtrM+npAC2OQY6CBjvl7KH9cs+UXcbezf6kp
+-----END CERTIFICATE-----
+```
+
+```
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number:
+            4f:3e:bb:57:d6:1f:74:10:b0:1c:78:cc:1c:9c:46:7e:d8:0c:a5:bd
+    Signature Algorithm: sha256WithRSAEncryption
+        Issuer: C=US, O=U.S. Government, CN=US Federal Test TLS CA 100
+        Validity
+            Not Before: Apr  4 20:30:08 2018 GMT
+            Not After : May 19 20:30:08 2018 GMT
+        Subject: C=US, O=U.S. Government, CN=OCSP Signing Certificate 100
+        Subject Public Key Info:
+            Public Key Algorithm: rsaEncryption
+                Public-Key: (2048 bit)
+                Modulus:
+                    00:c3:af:56:02:95:55:1d:81:4a:45:25:3c:d7:2f:
+                    74:3d:d9:1a:bf:85:e2:f9:f0:9b:4e:85:e1:9b:76:
+                    ba:10:cb:aa:a2:15:07:55:b8:9f:8b:24:00:42:2f:
+                    2d:2e:3c:03:bf:04:2c:8f:d6:59:42:03:5a:a8:6b:
+                    08:f4:fa:5c:f1:b6:0a:ac:b4:f7:3b:75:67:29:3a:
+                    b2:bf:e4:f6:d7:58:cf:96:3f:34:6e:2f:87:a2:1b:
+                    ff:33:cf:a6:86:0c:46:bb:0a:dd:a5:a9:c6:ba:36:
+                    f1:b8:7c:e8:d8:de:fe:e1:b5:16:3a:77:e8:71:6e:
+                    c9:c4:0e:da:a9:04:47:d3:7c:2d:26:e3:e2:73:0c:
+                    68:fe:8e:2a:ef:91:25:32:f4:b2:ff:1e:57:94:16:
+                    25:95:f3:f4:38:52:b2:86:16:d2:6a:00:4c:de:46:
+                    12:f4:0c:5d:fc:e7:93:2b:a7:be:af:13:24:2d:6d:
+                    e6:48:d3:d4:0a:9d:7c:81:3b:db:52:92:c1:39:41:
+                    35:ba:39:d5:87:2e:1d:9e:a0:7f:f5:f9:17:26:2b:
+                    cf:f6:f7:ce:f5:79:0b:08:28:1b:6a:7f:1f:56:ba:
+                    bd:aa:ef:6a:88:dc:c1:4a:f5:6f:ae:2b:8c:62:71:
+                    88:28:96:af:d1:50:7b:8a:bd:58:9c:75:6c:80:0e:
+                    cc:2d
+                Exponent: 65537 (0x10001)
+        X509v3 extensions:
+            X509v3 Authority Key Identifier:
+                keyid:7E:4E:2B:F1:64:B2:AD:AB:7F:62:91:30:30:D5:54:C6:D2:3B:55:E1
+
+            X509v3 Subject Key Identifier:
+                09:7E:B9:79:69:8D:B7:3F:11:BF:EC:8E:11:BE:0F:30:33:51:05:10
+            X509v3 Certificate Policies:
+                Policy: 2.16.840.1.101.3.2.1.3.43
+                Policy: 2.16.840.1.101.3.2.1.3.44
+                Policy: 2.23.140.1.2.1
+                Policy: 2.23.140.1.2.2
+
+            X509v3 Key Usage: critical
+                Digital Signature
+            X509v3 Extended Key Usage: critical
+                OCSP Signing
+            OCSP No Check:
+
+            Authority Information Access:
+                CA Issuers - URI:http://cert.issuing.pki-lab.gov/sign/USFEDTESTCA100.p7c
+
+    Signature Algorithm: sha256WithRSAEncryption
+         56:d0:0e:2c:2b:3f:61:aa:25:7c:7c:5b:d9:45:b7:77:c9:28:
+         5f:d7:af:5d:09:65:c3:96:0d:41:f0:47:43:d8:97:49:2c:62:
+         04:de:b8:79:b2:91:20:16:15:b3:cf:dd:37:9f:8d:89:85:74:
+         96:56:40:9c:4a:61:81:4d:ba:02:10:e9:ab:46:b1:b7:27:8d:
+         35:48:9f:bb:bc:d3:70:13:15:c4:c1:2d:ba:59:9a:d0:44:ef:
+         93:d2:22:ad:66:80:63:65:f5:05:54:4c:84:46:95:9d:13:1c:
+         b7:a7:ef:a6:34:41:1e:c4:66:5c:c3:97:46:7a:9d:b7:89:09:
+         0d:cc:df:03:65:5b:38:40:10:1a:da:0e:87:4e:9d:11:4b:eb:
+         dc:bf:8d:11:4d:13:bf:d3:28:b4:43:6e:21:f3:7d:59:cf:c5:
+         8d:b4:c3:e6:2e:bd:92:48:9a:6b:3c:56:2f:d9:f5:f6:37:fe:
+         59:b8:d7:96:aa:1f:38:1c:f5:81:d8:d0:1e:ce:c0:07:2f:31:
+         d0:58:2c:a8:d1:d1:a5:82:9e:23:3d:71:83:ed:af:b6:3b:a5:
+         1c:ad:f8:89:16:9a:ab:1a:37:e7:bc:a5:a3:1a:da:cc:fa:7a:
+         40:0b:63:90:63:a0:81:8e:f9:7b:28:7f:5c:b3:e5:17:71:b7:
+         b3:7f:a9:29
+```

--- a/sampleOpenSSLCertificates/2-tls-dv.md
+++ b/sampleOpenSSLCertificates/2-tls-dv.md
@@ -1,0 +1,156 @@
+```
+-----BEGIN CERTIFICATE-----
+MIIGUDCCBTigAwIBAgIVAIHf+rlkw4iJ6j6RQ2Uijsob/L+MMA0GCSqGSIb3DQEB
+CwUAMEwxCzAJBgNVBAYTAlVTMRgwFgYDVQQKEw9VLlMuIEdvdmVybm1lbnQxIzAh
+BgNVBAMTGlVTIEZlZGVyYWwgVGVzdCBUTFMgQ0EgMTAwMB4XDTE4MDQwNDIwNDcz
+OVoXDTE5MDUwNDIwNDczOVowLzELMAkGA1UEBhMCVVMxIDAeBgNVBAMTF2RlbG9y
+ZWFuLWR2LnBraS1sYWIuZ292MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKC
+AQEAmnfxWcm9wb9BrfAlsExmiofx4dvpuo4KDlujvfMdzmXFBVylALDGZG35R9ua
+hL/E+J1wyK3n0cdiSVkA18603Sh7fmXpgEk6Rmj+3tiUvVCnA4ogZgb5G3uasSKq
+2odZJoSwx/V+EGsx3nHMfmo1pjKSlue12fpGzFfrApKU2DoRnjIOWeuj1RXkBjQs
+Dx7uilDRXrDhZVyNP5p43UN263gSMZi8VK4veWokFwKjKZWNTQHkw2M7aXm02/lp
+51kvkc2W6m+FcAjcYCWrIhMpe2bemH+HnPOOMvIZnR34cNPOgtCT31D3e4bpjDuh
+lWk8AV++nUHdZo2Y6Z3qPmOujQIDAQABo4IDRDCCA0AwUgYDVR0gBEswSTA9Bgpg
+hkgBZQMCAQMrMC8wLQYIKwYBBQUHAgEWIWh0dHA6Ly9yZXBvc2l0b3J5LnBraS1s
+YWIuZ292L2NwczAIBgZngQwBAgEwHwYDVR0jBBgwFoAUfk4r8WSyrat/YpEwMNVU
+xtI7VeEwHQYDVR0OBBYEFPSbDuGdvQnyNg3Xg/MDGXn2mmV3MAwGA1UdEwEB/wQC
+MAAwDgYDVR0PAQH/BAQDAgWgMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcD
+AjAiBgNVHREEGzAZghdkZWxvcmVhbi1kdi5wa2ktbGFiLmdvdjB9BggrBgEFBQcB
+AQRxMG8wKAYIKwYBBQUHMAGGHGh0dHA6Ly9vY3NwLmRpc2EucGtpLWxhYi5nb3Yw
+QwYIKwYBBQUHMAKGN2h0dHA6Ly9jZXJ0Lmlzc3VpbmcucGtpLWxhYi5nb3Yvc2ln
+bi9VU0ZFRFRFU1RDQTEwMC5wN2MwRwYDVR0fBEAwPjA8oDqgOIY2aHR0cDovL2lz
+c3VpbmcuZGlzYS5wa2ktbGFiLmdvdi9jcmwvVVNGRURURVNUQ0ExMDAuY3JsMIIB
+fwYKKwYBBAHWeQIEAgSCAW8EggFrAWkAdgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+AAAAAAAAAAAAAAAAAWHDUvAbAAAEAwBHAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+dwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHDUvEhAAAEAwBI
+AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHYAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+AAAAAAAAAAAAAAAAAAFhw1LwxQAABAMARwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+MA0GCSqGSIb3DQEBCwUAA4IBAQBH561yMbnmtpiHxWGZxPzHeXC37zozAwH9GUk/
+QagqdviwaRCwsIp6rbZGmomJtCZwXo+7hepxu0QSO2eyoWHCZUNgEYYHJfEfDGfj
+Buzh6W3Q7djHPWVQGcIE05dzO2Xje7pQFn7a7GP6KKQ1gtEwquQfzYjq4XlWoaMN
+wAhdGYboHULfW7SQlHZHJj6yKVAJxVMdqviiH09aD+jjhsYyaDQyaJxSUU95ZNEY
+inSwcwxUReaIO97E1Ajbq4mTs7gx/y4Q17Z+7+TT0ML7mOMVQyPBlBbXaKOB7R6O
+JDwYkPp97+Ln3uaiS0Ds+R6lD6IBuEtMKtym9/wBWs08vOTh
+-----END CERTIFICATE-----
+```
+
+```
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number:
+            81:df:fa:b9:64:c3:88:89:ea:3e:91:43:65:22:8e:ca:1b:fc:bf:8c
+    Signature Algorithm: sha256WithRSAEncryption
+        Issuer: C=US, O=U.S. Government, CN=US Federal Test TLS CA 100
+        Validity
+            Not Before: Apr  4 20:47:39 2018 GMT
+            Not After : May  4 20:47:39 2019 GMT
+        Subject: C=US, CN=delorean-dv.pki-lab.gov
+        Subject Public Key Info:
+            Public Key Algorithm: rsaEncryption
+                Public-Key: (2048 bit)
+                Modulus:
+                    00:9a:77:f1:59:c9:bd:c1:bf:41:ad:f0:25:b0:4c:
+                    66:8a:87:f1:e1:db:e9:ba:8e:0a:0e:5b:a3:bd:f3:
+                    1d:ce:65:c5:05:5c:a5:00:b0:c6:64:6d:f9:47:db:
+                    9a:84:bf:c4:f8:9d:70:c8:ad:e7:d1:c7:62:49:59:
+                    00:d7:ce:b4:dd:28:7b:7e:65:e9:80:49:3a:46:68:
+                    fe:de:d8:94:bd:50:a7:03:8a:20:66:06:f9:1b:7b:
+                    9a:b1:22:aa:da:87:59:26:84:b0:c7:f5:7e:10:6b:
+                    31:de:71:cc:7e:6a:35:a6:32:92:96:e7:b5:d9:fa:
+                    46:cc:57:eb:02:92:94:d8:3a:11:9e:32:0e:59:eb:
+                    a3:d5:15:e4:06:34:2c:0f:1e:ee:8a:50:d1:5e:b0:
+                    e1:65:5c:8d:3f:9a:78:dd:43:76:eb:78:12:31:98:
+                    bc:54:ae:2f:79:6a:24:17:02:a3:29:95:8d:4d:01:
+                    e4:c3:63:3b:69:79:b4:db:f9:69:e7:59:2f:91:cd:
+                    96:ea:6f:85:70:08:dc:60:25:ab:22:13:29:7b:66:
+                    de:98:7f:87:9c:f3:8e:32:f2:19:9d:1d:f8:70:d3:
+                    ce:82:d0:93:df:50:f7:7b:86:e9:8c:3b:a1:95:69:
+                    3c:01:5f:be:9d:41:dd:66:8d:98:e9:9d:ea:3e:63:
+                    ae:8d
+                Exponent: 65537 (0x10001)
+        X509v3 extensions:
+            X509v3 Certificate Policies:
+                Policy: 2.16.840.1.101.3.2.1.3.43
+                  CPS: http://repository.pki-lab.gov/cps
+                Policy: 2.23.140.1.2.1
+
+            X509v3 Authority Key Identifier:
+                keyid:7E:4E:2B:F1:64:B2:AD:AB:7F:62:91:30:30:D5:54:C6:D2:3B:55:E1
+
+            X509v3 Subject Key Identifier:
+                F4:9B:0E:E1:9D:BD:09:F2:36:0D:D7:83:F3:03:19:79:F6:9A:65:77
+            X509v3 Basic Constraints: critical
+                CA:FALSE
+            X509v3 Key Usage: critical
+                Digital Signature, Key Encipherment
+            X509v3 Extended Key Usage:
+                TLS Web Server Authentication, TLS Web Client Authentication
+            X509v3 Subject Alternative Name:
+                DNS:delorean-dv.pki-lab.gov
+            Authority Information Access:
+                OCSP - URI:http://ocsp.disa.pki-lab.gov
+                CA Issuers - URI:http://cert.issuing.pki-lab.gov/sign/USFEDTESTCA100.p7c
+
+            X509v3 CRL Distribution Points:
+
+                Full Name:
+                  URI:http://issuing.disa.pki-lab.gov/crl/USFEDTESTCA100.crl
+
+            CT Precertificate SCTs:
+                Signed Certificate Timestamp:
+                    Version   : v1(0)
+                    Log ID    : 00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:
+                                00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00
+                    Timestamp : Feb 23 15:40:48.027 2018 GMT
+                    Extensions: none
+                    Signature : ecdsa-with-SHA256
+                                00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:
+                                00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:
+                                00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:
+                                00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:
+                                00:00:00:00:00:00:00
+                Signed Certificate Timestamp:
+                    Version   : v1(0)
+                    Log ID    : 00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:
+                                00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00
+                    Timestamp : Feb 23 15:40:48.289 2018 GMT
+                    Extensions: none
+                    Signature : ecdsa-with-SHA256
+                                00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:
+                                00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:
+                                00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:
+                                00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:
+                                00:00:00:00:00:00:00:00
+                Signed Certificate Timestamp:
+                    Version   : v1(0)
+                    Log ID    : 00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:
+                                00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00
+                    Timestamp : Feb 23 15:40:48.197 2018 GMT
+                    Extensions: none
+                    Signature : ecdsa-with-SHA256
+                                00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:
+                                00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:
+                                00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:
+                                00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:
+                                00:00:00:00:00:00:00
+    Signature Algorithm: sha256WithRSAEncryption
+         47:e7:ad:72:31:b9:e6:b6:98:87:c5:61:99:c4:fc:c7:79:70:
+         b7:ef:3a:33:03:01:fd:19:49:3f:41:a8:2a:76:f8:b0:69:10:
+         b0:b0:8a:7a:ad:b6:46:9a:89:89:b4:26:70:5e:8f:bb:85:ea:
+         71:bb:44:12:3b:67:b2:a1:61:c2:65:43:60:11:86:07:25:f1:
+         1f:0c:67:e3:06:ec:e1:e9:6d:d0:ed:d8:c7:3d:65:50:19:c2:
+         04:d3:97:73:3b:65:e3:7b:ba:50:16:7e:da:ec:63:fa:28:a4:
+         35:82:d1:30:aa:e4:1f:cd:88:ea:e1:79:56:a1:a3:0d:c0:08:
+         5d:19:86:e8:1d:42:df:5b:b4:90:94:76:47:26:3e:b2:29:50:
+         09:c5:53:1d:aa:f8:a2:1f:4f:5a:0f:e8:e3:86:c6:32:68:34:
+         32:68:9c:52:51:4f:79:64:d1:18:8a:74:b0:73:0c:54:45:e6:
+         88:3b:de:c4:d4:08:db:ab:89:93:b3:b8:31:ff:2e:10:d7:b6:
+         7e:ef:e4:d3:d0:c2:fb:98:e3:15:43:23:c1:94:16:d7:68:a3:
+         81:ed:1e:8e:24:3c:18:90:fa:7d:ef:e2:e7:de:e6:a2:4b:40:
+         ec:f9:1e:a5:0f:a2:01:b8:4b:4c:2a:dc:a6:f7:fc:01:5a:cd:
+         3c:bc:e4:e1
+```

--- a/sampleOpenSSLCertificates/2-tls-ov.md
+++ b/sampleOpenSSLCertificates/2-tls-ov.md
@@ -1,0 +1,157 @@
+```
+-----BEGIN CERTIFICATE-----
+MIIGiDCCBXCgAwIBAgIUaNXPvv8wuoyna/e6+qnCJ+7woWwwDQYJKoZIhvcNAQEL
+BQAwTDELMAkGA1UEBhMCVVMxGDAWBgNVBAoTD1UuUy4gR292ZXJubWVudDEjMCEG
+A1UEAxMaVVMgRmVkZXJhbCBUZXN0IFRMUyBDQSAxMDAwHhcNMTgwNDA0MjA0NzAy
+WhcNMTkwNTA0MjA0NzAyWjBoMQswCQYDVQQGEwJVUzEYMBYGA1UEChMPVS5TLiBH
+b3Zlcm5tZW50MR0wGwYDVQQIExREaXN0cmljdCBvZiBDb2x1bWJpYTEgMB4GA1UE
+AxMXZGVsb3JlYW4tb3YucGtpLWxhYi5nb3YwggEiMA0GCSqGSIb3DQEBAQUAA4IB
+DwAwggEKAoIBAQCad/FZyb3Bv0Gt8CWwTGaKh/Hh2+m6jgoOW6O98x3OZcUFXKUA
+sMZkbflH25qEv8T4nXDIrefRx2JJWQDXzrTdKHt+ZemASTpGaP7e2JS9UKcDiiBm
+Bvkbe5qxIqrah1kmhLDH9X4QazHeccx+ajWmMpKW57XZ+kbMV+sCkpTYOhGeMg5Z
+66PVFeQGNCwPHu6KUNFesOFlXI0/mnjdQ3breBIxmLxUri95aiQXAqMplY1NAeTD
+YztpebTb+WnnWS+RzZbqb4VwCNxgJasiEyl7Zt6Yf4ec844y8hmdHfhw086C0JPf
+UPd7humMO6GVaTwBX76dQd1mjZjpneo+Y66NAgMBAAGjggNEMIIDQDBSBgNVHSAE
+SzBJMD0GCmCGSAFlAwIBAywwLzAtBggrBgEFBQcCARYhaHR0cDovL3JlcG9zaXRv
+cnkucGtpLWxhYi5nb3YvY3BzMAgGBmeBDAECAjAfBgNVHSMEGDAWgBR+TivxZLKt
+q39ikTAw1VTG0jtV4TAdBgNVHQ4EFgQU9JsO4Z29CfI2DdeD8wMZefaaZXcwDAYD
+VR0TAQH/BAIwADAOBgNVHQ8BAf8EBAMCBaAwHQYDVR0lBBYwFAYIKwYBBQUHAwEG
+CCsGAQUFBwMCMCIGA1UdEQQbMBmCF2RlbG9yZWFuLW92LnBraS1sYWIuZ292MH0G
+CCsGAQUFBwEBBHEwbzAoBggrBgEFBQcwAYYcaHR0cDovL29jc3AuZGlzYS5wa2kt
+bGFiLmdvdjBDBggrBgEFBQcwAoY3aHR0cDovL2NlcnQuaXNzdWluZy5wa2ktbGFi
+Lmdvdi9zaWduL1VTRkVEVEVTVENBMTAwLnA3YzBHBgNVHR8EQDA+MDygOqA4hjZo
+dHRwOi8vaXNzdWluZy5kaXNhLnBraS1sYWIuZ292L2NybC9VU0ZFRFRFU1RDQTEw
+MC5jcmwwggF/BgorBgEEAdZ5AgQCBIIBbwSCAWsBaQB2AAAAAAAAAAAAAAAAAAAA
+AAAAAAAAAAAAAAAAAAAAAAAAAAABYcNS8BsAAAQDAEcAAAAAAAAAAAAAAAAAAAAA
+AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+AAAAAAAAAAB3AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABYcNS
+8SEAAAQDAEgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAdgAAAAAAAAAAAAAAAAAA
+AAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHDUvDFAAAEAwBHAAAAAAAAAAAAAAAAAAAA
+AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+AAAAAAAAAAAwDQYJKoZIhvcNAQELBQADggEBAEZBwl+igSB72zuLEweMEOcouR0a
+pxLw7iECajWexvuXcgbnwjWwIhs7cWPSg1QqyvgZrQhzPNIq2O7kJliswXXYIpzA
+r6pgOVzeA47fs/XNqfs9e7JoNKoc6sruCHjKYqGscT636BtZuwK+25riSEvDbjdH
+wNH1v8ZnmBvtgYVcIxQvpJaK+W43W+NwlobIcHq99wh5LoxX5KkZyQxcdmpaNqfI
+d4Fkz3nt3fNjME2b0n6dv9CMId7us9u4NbBLwK8Uvaaj4Py/l2mPqtG46dpLKTCe
+MAdj6eipZxHo9dcIDY0G6JIzZ27/S/b83fAoPeXYFJLbLdhnJiH7TDPkjZU=
+-----END CERTIFICATE-----
+```
+
+```
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number:
+            68:d5:cf:be:ff:30:ba:8c:a7:6b:f7:ba:fa:a9:c2:27:ee:f0:a1:6c
+    Signature Algorithm: sha256WithRSAEncryption
+        Issuer: C=US, O=U.S. Government, CN=US Federal Test TLS CA 100
+        Validity
+            Not Before: Apr  4 20:47:02 2018 GMT
+            Not After : May  4 20:47:02 2019 GMT
+        Subject: C=US, O=U.S. Government, ST=District of Columbia, CN=delorean-ov.pki-lab.gov
+        Subject Public Key Info:
+            Public Key Algorithm: rsaEncryption
+                Public-Key: (2048 bit)
+                Modulus:
+                    00:9a:77:f1:59:c9:bd:c1:bf:41:ad:f0:25:b0:4c:
+                    66:8a:87:f1:e1:db:e9:ba:8e:0a:0e:5b:a3:bd:f3:
+                    1d:ce:65:c5:05:5c:a5:00:b0:c6:64:6d:f9:47:db:
+                    9a:84:bf:c4:f8:9d:70:c8:ad:e7:d1:c7:62:49:59:
+                    00:d7:ce:b4:dd:28:7b:7e:65:e9:80:49:3a:46:68:
+                    fe:de:d8:94:bd:50:a7:03:8a:20:66:06:f9:1b:7b:
+                    9a:b1:22:aa:da:87:59:26:84:b0:c7:f5:7e:10:6b:
+                    31:de:71:cc:7e:6a:35:a6:32:92:96:e7:b5:d9:fa:
+                    46:cc:57:eb:02:92:94:d8:3a:11:9e:32:0e:59:eb:
+                    a3:d5:15:e4:06:34:2c:0f:1e:ee:8a:50:d1:5e:b0:
+                    e1:65:5c:8d:3f:9a:78:dd:43:76:eb:78:12:31:98:
+                    bc:54:ae:2f:79:6a:24:17:02:a3:29:95:8d:4d:01:
+                    e4:c3:63:3b:69:79:b4:db:f9:69:e7:59:2f:91:cd:
+                    96:ea:6f:85:70:08:dc:60:25:ab:22:13:29:7b:66:
+                    de:98:7f:87:9c:f3:8e:32:f2:19:9d:1d:f8:70:d3:
+                    ce:82:d0:93:df:50:f7:7b:86:e9:8c:3b:a1:95:69:
+                    3c:01:5f:be:9d:41:dd:66:8d:98:e9:9d:ea:3e:63:
+                    ae:8d
+                Exponent: 65537 (0x10001)
+        X509v3 extensions:
+            X509v3 Certificate Policies:
+                Policy: 2.16.840.1.101.3.2.1.3.44
+                  CPS: http://repository.pki-lab.gov/cps
+                Policy: 2.23.140.1.2.2
+
+            X509v3 Authority Key Identifier:
+                keyid:7E:4E:2B:F1:64:B2:AD:AB:7F:62:91:30:30:D5:54:C6:D2:3B:55:E1
+
+            X509v3 Subject Key Identifier:
+                F4:9B:0E:E1:9D:BD:09:F2:36:0D:D7:83:F3:03:19:79:F6:9A:65:77
+            X509v3 Basic Constraints: critical
+                CA:FALSE
+            X509v3 Key Usage: critical
+                Digital Signature, Key Encipherment
+            X509v3 Extended Key Usage:
+                TLS Web Server Authentication, TLS Web Client Authentication
+            X509v3 Subject Alternative Name:
+                DNS:delorean-ov.pki-lab.gov
+            Authority Information Access:
+                OCSP - URI:http://ocsp.disa.pki-lab.gov
+                CA Issuers - URI:http://cert.issuing.pki-lab.gov/sign/USFEDTESTCA100.p7c
+
+            X509v3 CRL Distribution Points:
+
+                Full Name:
+                  URI:http://issuing.disa.pki-lab.gov/crl/USFEDTESTCA100.crl
+
+            CT Precertificate SCTs:
+                Signed Certificate Timestamp:
+                    Version   : v1(0)
+                    Log ID    : 00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:
+                                00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00
+                    Timestamp : Feb 23 15:40:48.027 2018 GMT
+                    Extensions: none
+                    Signature : ecdsa-with-SHA256
+                                00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:
+                                00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:
+                                00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:
+                                00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:
+                                00:00:00:00:00:00:00
+                Signed Certificate Timestamp:
+                    Version   : v1(0)
+                    Log ID    : 00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:
+                                00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00
+                    Timestamp : Feb 23 15:40:48.289 2018 GMT
+                    Extensions: none
+                    Signature : ecdsa-with-SHA256
+                                00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:
+                                00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:
+                                00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:
+                                00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:
+                                00:00:00:00:00:00:00:00
+                Signed Certificate Timestamp:
+                    Version   : v1(0)
+                    Log ID    : 00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:
+                                00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00
+                    Timestamp : Feb 23 15:40:48.197 2018 GMT
+                    Extensions: none
+                    Signature : ecdsa-with-SHA256
+                                00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:
+                                00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:
+                                00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:
+                                00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:
+                                00:00:00:00:00:00:00
+    Signature Algorithm: sha256WithRSAEncryption
+         46:41:c2:5f:a2:81:20:7b:db:3b:8b:13:07:8c:10:e7:28:b9:
+         1d:1a:a7:12:f0:ee:21:02:6a:35:9e:c6:fb:97:72:06:e7:c2:
+         35:b0:22:1b:3b:71:63:d2:83:54:2a:ca:f8:19:ad:08:73:3c:
+         d2:2a:d8:ee:e4:26:58:ac:c1:75:d8:22:9c:c0:af:aa:60:39:
+         5c:de:03:8e:df:b3:f5:cd:a9:fb:3d:7b:b2:68:34:aa:1c:ea:
+         ca:ee:08:78:ca:62:a1:ac:71:3e:b7:e8:1b:59:bb:02:be:db:
+         9a:e2:48:4b:c3:6e:37:47:c0:d1:f5:bf:c6:67:98:1b:ed:81:
+         85:5c:23:14:2f:a4:96:8a:f9:6e:37:5b:e3:70:96:86:c8:70:
+         7a:bd:f7:08:79:2e:8c:57:e4:a9:19:c9:0c:5c:76:6a:5a:36:
+         a7:c8:77:81:64:cf:79:ed:dd:f3:63:30:4d:9b:d2:7e:9d:bf:
+         d0:8c:21:de:ee:b3:db:b8:35:b0:4b:c0:af:14:bd:a6:a3:e0:
+         fc:bf:97:69:8f:aa:d1:b8:e9:da:4b:29:30:9e:30:07:63:e9:
+         e8:a9:67:11:e8:f5:d7:08:0d:8d:06:e8:92:33:67:6e:ff:4b:
+         f6:fc:dd:f0:28:3d:e5:d8:14:92:db:2d:d8:67:26:21:fb:4c:
+         33:e4:8d:95
+```


### PR DESCRIPTION
This pull request is in an effort to post sample root, subordinate, and end-entity certificates that were created via OpenSSL.

This request supports resolution of the following issues:
- #511 - "Make certificatePolicies:policyQualifiers required in the profile"
- #507 - "Update certificate profiles for Name Constraints"

A few notes about the OpenSSL generated certificates:
- To avoid confusion with the actual test CAs, the root/subordinate contain a "100" identifier (e.g. US Federal Test TLS CA100)
- TLS certificate SCT data is fake (signed object values are just populated with 0's)
- SIA/AIA/CRLDP URIs are non-functional - and could likely benefit from further standardization

The goal of these certificates is to promote discussion surrounding the existing profiles in hopes of identifying necessary updates.
