### PR TITLE
TLS CP Ballot 19-01  | Incorporate CAB Ballot SC19

### DIFF
--- a/certificate-policy.md
+++ b/certificate-policy.md
@@ -1837,7 +1837,7 @@ No stipulation.
 
 **DNS CAA Email Contact**: The email address placed in the CAA contactemail property.
 
-**DNS CAA Phone Contact**: The pohne number place in the CAA contactphone property.
+**DNS CAA Phone Contact**: The pohne number placed in the CAA contactphone property.
 
 **DNS TXT Record Email Contact**: The email address placed on the “_validation-contactemail” of the DNS TXT record.
 

--- a/certificate-policy.md
+++ b/certificate-policy.md
@@ -3,6 +3,7 @@
 | **Ver.** | **Change Proposal** | **Description** | **Adopted** | **Effective Date** |
 | --- | --- | --- | --- | --- |
 | 1.0.0 | None | Version 1.0 of the Certificate Policy Adopted | May 9, 2019 | May 9, 2019 |
+| 1.1 | 19-01 | Incororate CAB Forum Ballot SC-19 | Aug 1, 2019 | Aug 1, 2019 |
 
 
 ## 1. INTRODUCTION

--- a/certificate-policy.md
+++ b/certificate-policy.md
@@ -375,6 +375,9 @@ This validation method defined by the Baseline Requirements is not allowed under
 ##### 3.2.2.4.16 Phone Contact with DNS TXT Record Phone Contact
 This validation method defined by the Baseline Requirements is not allowed under this CP.
 
+##### 3.2.2.4.17 Phone Contact with DNS CAA Phone Contact
+This validation method defined by the Baseline Requirements is not allowed under this CP.
+
 #### 3.2.2.5 Authentication for an IP Address
 IP Addresses are not allowed in the certificate profiles under this CP.
 
@@ -1833,6 +1836,8 @@ No stipulation.
 **Delegated Third Party**: A natural person or Legal Entity that is not the CA but is authorized by the CA to assist in the Certificate Management Process by performing or fulfilling one or more of the CA requirements found herein.
 
 **DNS CAA Email Contact**: The email address placed in the CAA contactemail property.
+
+**DNS CAA Phone Contact**: The pohne number place in the CAA contactphone property.
 
 **DNS TXT Record Email Contact**: The email address placed on the “_validation-contactemail” of the DNS TXT record.
 


### PR DESCRIPTION
**TLS Certificate Policy Change Proposal Number:** 2019-01
**Subject:** Incorporate CAB Forum Ballot SC-19
**Date:** July 2, 2019
**Version of Certificate Policy to Be Changed:** _U.S. Federal Public Trust TLS Certificate Policy Version 1.0_
**Change Advocate:** Federal PKI Management Authority (FPKIMA)
**Change Summary:** This ballot will incorporate changes from [CAB Forum Ballot SC19: Phone Contract with DNS CAA Phone Contact V2](https://cabforum.org/2019/05/21/ballot-sc19-phone-contact-with-dns-caa-phone-contact-v2/). This is an editorial update to maintain compliance with the CAB Forum Baseline Requirements because the Federal Public Trust TLS does not use a phone contact verification method.
**Background:** The U.S. Federal Public Trust TLS issues publicly trusted TLS certificates. To maintain compliance with Root Program requirements for publicly trusted TLS certificates, the U.S. Federal Public Trust TLS must maintain alignment with the CAB Forum Baseline Requirements.
**Specific Changes:** Included in pull request
**Issues Fixed:** #611
**Estimated Cost:** None. Editorial update to CP and CPS.
**Implementation Date:** Date of approval.
**Prerequisites for Adoption:" None.
** Plan to Meet Prerequisites:** Not applicable.
**Approval and Coordination Dates:**
Date presented to Federal TLS Working Group:
Date change released for comment:
Date approved by Policy Authority: